### PR TITLE
remove overflow-y-scroll from tables

### DIFF
--- a/components/mdx/Table.tsx
+++ b/components/mdx/Table.tsx
@@ -1,6 +1,6 @@
 export function Table(props) {
   return (
-    <div className="max-w-full overflow-auto overflow-y-scroll">
+    <div className="max-w-full overflow-auto">
       <table
         className="align-middle w-full break-words text-sm rounded border-collapse overflow-hidden"
         {...props}


### PR DESCRIPTION
it adds a pointless right-side scrollbar to tables on Windows, and has no benefit