### PR TITLE
Add scrollbar theming

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,6 +36,12 @@ module.exports = {
         "theme-dark-sidebar": "#2e3136",
         "theme-dark-sidebar-text": "#b9bbbe",
         "theme-dark-sidebar-hover": "#393C43",
+        
+        "theme-light-scrollbar-thumb":  "#cccccc",
+        "theme-light-scrollbar-track":  "#f2f2f2",
+        
+        "theme-dark-scrollbar-thumb":  "#202225",
+        "theme-dark-scrollbar-track":  "#2f3136",
       },
 
       // TODO: Change these out for whatever legitimate font family names discord uses,


### PR DESCRIPTION
Instead of using default browser scrollbars, preferably focus on Discord themed scrollbars.

Not sure where to place this, but when that place is found, this pr will be ready for review:
```css
::-webkit-scrollbar {
    height: 16px;
    width: 16px;
}

::-webkit-scrollbar-thumb {
    background-color: var(theme-light-scrollbar-thumb); // theme-dark-scrollbar-thumb
    border: 4px solid transparent;
    border-radius: 8px;
    min-height: 40px;
    background-clip: padding-box;
}

::-webkit-scrollbar-track {
    background-color: var(theme-light-scrollbar-track); // theme-dark-scrollbar-track
    border: 4px solid transparent;
    border-radius: 8px;
    margin-bottom: 8px;
    background-clip: padding-box;
}
```