### PR TITLE
Add commonly used components to MDXProvider

### DIFF
--- a/components/MDX.tsx
+++ b/components/MDX.tsx
@@ -16,8 +16,11 @@ import Emphasis from "./mdx/Emphasis";
 import StrikeThrough from "./mdx/StrikeThrough";
 import HorizontalRule from "./mdx/HorizontalRule";
 import Anchor from "./mdx/Anchor";
-import Image from "./mdx/Image";
 import InlineCode from "./mdx/InlineCode";
+
+import RouteHeader from "./RouteHeader";
+import Alert from "./Alert";
+import Image from "next/image";
 
 const COMPONENTS = {
   wrapper: (props: any) => <ContentWrapper {...props} />,
@@ -43,7 +46,11 @@ const COMPONENTS = {
   delete: StrikeThrough,
   hr: HorizontalRule,
   a: Anchor,
-  img: Image,
+
+  // Custom components
+  Image,
+  Alert,
+  RouteHeader
 };
 
 interface MDXProps {

--- a/components/RouteHeader.tsx
+++ b/components/RouteHeader.tsx
@@ -1,7 +1,6 @@
 import { Fragment } from "react";
 import classNames from "classnames";
 import { H2 } from "./mdx/Heading";
-import InlineCode from "./mdx/InlineCode";
 
 type RESTMethod = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
 

--- a/pages/dispatch/branches-and-builds.mdx
+++ b/pages/dispatch/branches-and-builds.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Branches and Builds
 
 <Alert type="info">

--- a/pages/dispatch/dispatch-and-you.mdx
+++ b/pages/dispatch/dispatch-and-you.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Dispatch and You
 
 <Alert type="info">

--- a/pages/dispatch/error-codes.mdx
+++ b/pages/dispatch/error-codes.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Error Codes
 
 <Alert type="info">

--- a/pages/dispatch/field-values.mdx
+++ b/pages/dispatch/field-values.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Predefined Field Values
 
 <Alert type="info">

--- a/pages/dispatch/list-of-commands.mdx
+++ b/pages/dispatch/list-of-commands.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # List of Commands
 
 <Alert type="info">

--- a/pages/game-and-server-management/alpha-and-beta-testing.mdx
+++ b/pages/game-and-server-management/alpha-and-beta-testing.mdx
@@ -1,6 +1,3 @@
-import Image from "next/image";
-import Alert from "../../components/Alert";
-
 # Alpha and Beta Testing
 
 Alphas and betas are a critical part of a game's development lifecycle. We understand the value of getting feedback early and often and involving your community early on. That's why we've built some awesome alpha and beta testing functionality for you!

--- a/pages/game-and-server-management/how-to-get-your-game-on-discord.mdx
+++ b/pages/game-and-server-management/how-to-get-your-game-on-discord.mdx
@@ -1,6 +1,3 @@
-import Image from "next/image";
-import Alert from "../../components/Alert";
-
 # How to Get Your Game on Discord
 
 <Alert type="warn">

--- a/pages/game-and-server-management/special-channels.mdx
+++ b/pages/game-and-server-management/special-channels.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Store Channels
 
 One of the new flagship features of Verified Servers and Game Servers are the ability to host your store pages directly in your server. We know that community is everything for games, and that your server is already the place where your community lives. Rather than the friction and impersonality of traditional storefronts, you can let your fans find your game in the cozy comfort of their home (your server!).

--- a/pages/game-sdk/achievements.mdx
+++ b/pages/game-sdk/achievements.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Achievements
 
 <Alert type="info">

--- a/pages/game-sdk/activities.mdx
+++ b/pages/game-sdk/activities.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Activities
 
 <Alert type="info">

--- a/pages/game-sdk/applications.mdx
+++ b/pages/game-sdk/applications.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Applications
 
 <Alert type="info">

--- a/pages/game-sdk/discord-voice.mdx
+++ b/pages/game-sdk/discord-voice.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Voice
 
 <Alert type="info">

--- a/pages/game-sdk/discord.mdx
+++ b/pages/game-sdk/discord.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Discord
 
 <Alert type="info">

--- a/pages/game-sdk/images.mdx
+++ b/pages/game-sdk/images.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Images
 
 <Alert type="info">

--- a/pages/game-sdk/lobbies.mdx
+++ b/pages/game-sdk/lobbies.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Lobbies
 
 <Alert type="info">

--- a/pages/game-sdk/networking.mdx
+++ b/pages/game-sdk/networking.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Networking
 
 <Alert type="info">

--- a/pages/game-sdk/overlay.mdx
+++ b/pages/game-sdk/overlay.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Overlay
 
 <Alert type="info">

--- a/pages/game-sdk/relationships.mdx
+++ b/pages/game-sdk/relationships.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Relationships
 
 <Alert type="info">

--- a/pages/game-sdk/sdk-starter-guide.mdx
+++ b/pages/game-sdk/sdk-starter-guide.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # SDK Starter Guide
 
 <Alert type="info">
@@ -242,7 +240,7 @@ You're ready to go! Check out the rest of the documentation for more info on how
 ## Code Primer - No Engine (Cpp)
 
 In your project folder, you'll want to make something like a "discord-files" folder, for organization. In that folder, copy all the `.h` and `.cpp` files from the zip.
-You want to include all the header and source files respectively in your project
+You want to include all the header and source files respectively in your project.
 
 ![Correct Files](cpp-files-sdk.png)
 

--- a/pages/game-sdk/storage.mdx
+++ b/pages/game-sdk/storage.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Storage
 
 <Alert type="info">

--- a/pages/game-sdk/store.mdx
+++ b/pages/game-sdk/store.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Store
 
 <Alert type="info">

--- a/pages/game-sdk/users.mdx
+++ b/pages/game-sdk/users.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Users
 
 <Alert type="info">

--- a/pages/interactions/application-commands.mdx
+++ b/pages/interactions/application-commands.mdx
@@ -1,7 +1,3 @@
-import Alert from "../../components/Alert";
-import RouteHeader from "../../components/RouteHeader";
-import InlineCode from "../../components/mdx/InlineCode";
-
 # Application Commands
 
 Application commands are commands that an application can register to Discord. They provide users a first-class way of interacting directly with your application that feels deeply integrated into Discord.

--- a/pages/interactions/receiving-and-responding.mdx
+++ b/pages/interactions/receiving-and-responding.mdx
@@ -1,6 +1,3 @@
-import Alert from "../../components/Alert";
-import RouteHeader from "../../components/RouteHeader";
-
 # Interactions
 
 An **[Interaction](#interaction-object)** is the message that your application receives when a user uses an application command or a message component.

--- a/pages/reference.mdx
+++ b/pages/reference.mdx
@@ -1,5 +1,3 @@
-import Image from "next/image";
-import Alert from "../components/Alert.tsx";
 import Snowflake from "../components/Snowflake.tsx";
 
 # API Reference

--- a/pages/resources/audit-log.mdx
+++ b/pages/resources/audit-log.mdx
@@ -1,6 +1,3 @@
-import Alert from "../../components/Alert";
-import RouteHeader from "../../components/RouteHeader";
-
 # Audit Logs Resource
 
 ## Audit Logs

--- a/pages/resources/channel.mdx
+++ b/pages/resources/channel.mdx
@@ -1,6 +1,3 @@
-import Alert from "../../components/Alert";
-import RouteHeader from "../../components/RouteHeader";
-
 # Channels Resource
 
 ### Channel Object
@@ -1142,7 +1139,7 @@ Note that in multipart form data, the `embeds`, `allowed_mentions`, and `attachm
 **If you supply a `payload_json` form value, all fields except for `file` fields will be ignored in the form data**.
 
 </Alert>
- 
+
 <Alert type="info">
 
 All parameters to this endpoint are optional and nullable.

--- a/pages/resources/emoji.mdx
+++ b/pages/resources/emoji.mdx
@@ -1,6 +1,3 @@
-import Alert from "../../components/Alert";
-import RouteHeader from "../../components/RouteHeader";
-
 # Emoji Resource
 
 <Alert type="warn">

--- a/pages/resources/guild-template.mdx
+++ b/pages/resources/guild-template.mdx
@@ -1,6 +1,3 @@
-import Alert from "../../components/Alert";
-import RouteHeader from "../../components/RouteHeader";
-
 # Guild Template Resource
 
 ### Guild Template Object

--- a/pages/resources/guild.mdx
+++ b/pages/resources/guild.mdx
@@ -1,6 +1,3 @@
-import Alert from "../../components/Alert";
-import RouteHeader from "../../components/RouteHeader";
-
 # Guild Resource
 
 Guilds in Discord represent an isolated collection of users and channels, and are often referred to as "servers" in the UI.

--- a/pages/resources/invite.mdx
+++ b/pages/resources/invite.mdx
@@ -1,6 +1,3 @@
-import Alert from "../../components/Alert";
-import RouteHeader from "../../components/RouteHeader";
-
 # Invite Resource
 
 ### Invite Object

--- a/pages/resources/stage-instance.mdx
+++ b/pages/resources/stage-instance.mdx
@@ -1,6 +1,3 @@
-import Alert from "../../components/Alert";
-import RouteHeader from "../../components/RouteHeader";
-
 # Stage Instance Resource
 
 A _Stage Instance_ holds information about a live stage.

--- a/pages/resources/sticker.mdx
+++ b/pages/resources/sticker.mdx
@@ -1,6 +1,3 @@
-import Alert from "../../components/Alert";
-import RouteHeader from "../../components/RouteHeader";
-
 # Sticker Resource
 
 ### Sticker Object

--- a/pages/resources/user.mdx
+++ b/pages/resources/user.mdx
@@ -1,6 +1,3 @@
-import Alert from "../../components/Alert.tsx";
-import RouteHeader from "../../components/RouteHeader";
-
 # Users Resource
 
 Users in Discord are generally considered the base entity. Users can spawn across the entire platform, be members of

--- a/pages/resources/voice.mdx
+++ b/pages/resources/voice.mdx
@@ -1,5 +1,3 @@
-import RouteHeader from "../../components/RouteHeader";
-
 # Voice Resource
 
 ### Voice State Object

--- a/pages/resources/webhook.mdx
+++ b/pages/resources/webhook.mdx
@@ -1,6 +1,3 @@
-import Alert from "../../components/Alert";
-import RouteHeader from "../../components/RouteHeader";
-
 # Webhook Resource
 
 Webhooks are a low-effort way to post messages to channels in Discord. They do not require a bot user or authentication to use.

--- a/pages/rich-presence/best-practices.mdx
+++ b/pages/rich-presence/best-practices.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Rich Presence Best Practices
 
 <Alert type="danger">

--- a/pages/rich-presence/faq.mdx
+++ b/pages/rich-presence/faq.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Rich Presence FAQ
 
 <Alert type="danger">

--- a/pages/rich-presence/how-to.mdx
+++ b/pages/rich-presence/how-to.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Introducing Rich Presence
 
 <Alert type="danger">

--- a/pages/rich-presence/launch-checklist.mdx
+++ b/pages/rich-presence/launch-checklist.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Rich Presence Launch Checklist
 
 <Alert type="danger">

--- a/pages/topics/certified-devices.mdx
+++ b/pages/topics/certified-devices.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Certified Devices
 
 Baked into Discord is the ability for hardware manufacturers to tell us a little more about the certified devices that are plugged into a user's computer. Unfortunately, no, you can't show that a user's PUBG Chicken Dinner was all thanks to the amazing TotallyRealHardware RGB Mouse and Keyboard Set Extraordinaire™, but you _can_ give them an amazing experience using your hardware with Discord!

--- a/pages/topics/gateway.mdx
+++ b/pages/topics/gateway.mdx
@@ -1,6 +1,3 @@
-import Alert from "../../components/Alert";
-import RouteHeader from "../../components/RouteHeader";
-
 # Gateways
 
 Gateways are Discord's form of real-time communication over secure WebSockets. Clients will receive events and data over the gateway they are connected to and send data over the REST API. The API for interacting with Gateways is complex and fairly unforgiving, therefore it's highly recommended you read _all_ of the following documentation before writing a custom implementation.

--- a/pages/topics/oauth2.mdx
+++ b/pages/topics/oauth2.mdx
@@ -1,6 +1,3 @@
-import Alert from "../../components/Alert";
-import RouteHeader from "../../components/RouteHeader";
-
 # OAuth2
 
 OAuth2 enables application developers to build applications that utilize authentication and data from the Discord API. Within Discord, there are multiple types of OAuth2 authentication. We support the authorization code grant, the implicit grant, client credentials, and some modified special-for-Discord flows for Bots and Webhooks

--- a/pages/topics/rate-limits.mdx
+++ b/pages/topics/rate-limits.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Rate Limits
 
 Discord's API rate limits requests in order to prevent abuse and overload of our services. Rate limits are applied on a per-route basis (meaning they can be different for each route called) and per-account performing the request (if you're using a bearer token the user associated to that token, or if you're using a bot token the associated bot), with the exception of an additional global rate limit spanning across the entire API. Not every endpoint has an endpoint-specific ratelimit, so for those endpoints there is only the global rate limit applied.

--- a/pages/topics/rpc.mdx
+++ b/pages/topics/rpc.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # RPC
 
 <Alert type="danger">

--- a/pages/topics/teams.mdx
+++ b/pages/topics/teams.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Teams
 
 Teams are groups of developers on Discord who want to collaborate on apps. On other platforms, these may be referred to as "organizations", "companies", or "teams". We went with the name Teams because it best encompassed all the awesome conglomerates of devs that work together to make awesome things on Discord. Also, we never got picked for kickball in gym class, so now we get to be on a team.

--- a/pages/topics/threads.mdx
+++ b/pages/topics/threads.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Threads
 
 [Threads](/resources/channel#channel-object) are a new Discord feature. Threads can be thought of as temporary sub-channels inside an existing channel, to help better organize conversation in a busy channel.

--- a/pages/topics/voice-connections.mdx
+++ b/pages/topics/voice-connections.mdx
@@ -1,5 +1,3 @@
-import Alert from "../../components/Alert";
-
 # Voice
 
 Voice connections operate in a similar fashion to the [Gateway](/topics/gateway#gateways) connection. However, they use a different set of payloads and a separate UDP-based connection for voice data transmission. Because UDP is used for both receiving and transmitting voice data, your client _must_ be able to receive UDP packets, even through a firewall or NAT (see [UDP Hole Punching](https://en.wikipedia.org/wiki/UDP_hole_punching) for more information). The Discord Voice servers implement functionality (see [IP Discovery](#ip-discovery)) for discovering the local machines remote UDP IP/Port, which can assist in some network configurations.


### PR DESCRIPTION
Removes the need to import `Image`, `Alert`, `RouteHeader` or `InlineCode` when using them in MDX files.