### PR TITLE
fix: remove unused prop setSidebarOpen on Header

### DIFF
--- a/components/mdx/ContentWrapper.tsx
+++ b/components/mdx/ContentWrapper.tsx
@@ -7,11 +7,9 @@ interface ContentWrapperProps {
 }
 
 export default function ContentWrapper({ children }: ContentWrapperProps) {
-  const { setOpen } = useContext(MenuContext);
-
   return (
     <main className="relative flex flex-1 flex-col items-center focus:outline-none overflow-y-auto">
-      <Header setSidebarOpen={setOpen} />
+      <Header />
       <div className="pt-4 px-4 w-full max-w-6xl sm:pt-0 sm:px-6 lg:px-10">
         <article className="m-auto">{children}</article>
       </div>


### PR DESCRIPTION
This just removes the `setSidebarOpen` prop that the `ContentWrapper` tries to set on the `Header` element, which goes unused anyway since the `Header` just gets the value from the context.