### PR TITLE
Add floating copy button to code blocks

### DIFF
--- a/components/Copy.tsx
+++ b/components/Copy.tsx
@@ -6,7 +6,7 @@ interface CopyButtonProps {
   children: React.ReactNode;
 }
 
-export default function CopyButton ({ text, children }: CopyButtonProps) {
+export default function CopyButton({ text, children }: CopyButtonProps) {
   const { copy, status } = useClipboard(text);
   let value = children;
 

--- a/components/mdx/Code.tsx
+++ b/components/mdx/Code.tsx
@@ -74,7 +74,7 @@ export default function Code({
     breakWords = true;
   }
 
-  const hasCopy = props.copy || language === "copy";
+  const hasCopy = /*props.copy || language === "copy"*/ true;
   const isTerminal = props.terminal || language === "terminal";
   const hasLines = file != null || props.lines;
 
@@ -83,7 +83,7 @@ export default function Code({
   );
 
   return (
-    <div className="code-block relative my-6 font-mono rounded-md">
+    <div className="code-block relative my-3 font-mono rounded-md">
       <InfoBar fileName={file} language={language} />
       <Highlight {...defaultProps} code={children} language={language}>
         {({
@@ -99,13 +99,6 @@ export default function Code({
               blockClassName
             )}
           >
-            {(props.copy || language === "copy") && (
-              <div className="copy-button">
-                <CopyButton text={children}>
-                  <CopyIcon />
-                </CopyButton>
-              </div>
-            )}
             <code className="p-4 rounded-md">
               {cleanTokens(tokens).map((line, i) => {
                 const lineClass = {};
@@ -183,6 +176,13 @@ export default function Code({
                   </div>
                 );
               })}
+              {hasCopy && (
+                <div className="copy-button absolute bottom-1 right-2 hidden p-3 transition md:block">
+                  <CopyButton text={children}>
+                    <CopyIcon class="w-5" />
+                  </CopyButton>
+                </div>
+              )}
             </code>
           </pre>
         )}

--- a/components/mdx/Code.tsx
+++ b/components/mdx/Code.tsx
@@ -176,17 +176,17 @@ export default function Code({
                   </div>
                 );
               })}
-              {hasCopy && (
-                <div className="copy-button absolute bottom-1 right-2 hidden p-3 transition md:block">
-                  <CopyButton text={children}>
-                    <CopyIcon class="w-5" />
-                  </CopyButton>
-                </div>
-              )}
             </code>
           </pre>
         )}
       </Highlight>
+      {hasCopy && (
+        <div className="copy-button absolute bottom-4 right-2 hidden p-3 transition md:block">
+          <CopyButton text={children}>
+            <CopyIcon className="w-5" />
+          </CopyButton>
+        </div>
+      )}
     </div>
   );
 }

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -1,3 +1,11 @@
 abbr[title].no-underline {
   text-decoration: none;
 }
+
+code .copy-button {
+  opacity: 0;
+}
+
+code:hover .copy-button {
+  opacity: 100;
+}

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -2,10 +2,10 @@ abbr[title].no-underline {
   text-decoration: none;
 }
 
-code .copy-button {
+.code-block .copy-button {
   opacity: 0;
 }
 
-code:hover .copy-button {
+.code-block:hover .copy-button {
   opacity: 100;
 }


### PR DESCRIPTION
Using the incomplete copy button code, I fixed some stuff and added some styles to make it appear when hovering over code blocks.
I made it only visible on desktop for now, I'm not sure how to implement it for mobile yet.

![image](https://user-images.githubusercontent.com/28990589/132077735-aa9f140a-7892-4bdd-98bb-0b3aec20e46d.png)