### PR TITLE
Prevent caret from highlighting menu items

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -83,9 +83,9 @@ function NavigationLink({
     <Fragment>
       <span className={classes}>
         {subLinks != null && (
-          <a onClick={toggle} className="pl-2">
+          <button onClick={toggle} className="pl-2">
             <CaretFill className={caretClasses} />
-          </a>
+          </button>
         )}
         <Link href={href}>
           <a className={linkClasses}>{children}</a>


### PR DESCRIPTION
Before, the caret was a `a` element without href, causing the menu text to highlight when clicked in rapid succession.
I changed it to a button element. I'm not sure if this is the right/best approach, but it works :^)